### PR TITLE
add subscribe request to pending requests

### DIFF
--- a/spine/device_local.go
+++ b/spine/device_local.go
@@ -57,8 +57,7 @@ func (r *DeviceLocalImpl) HandleEvent(payload EventPayload) {
 	if payload.EventType == EventTypeDeviceChange && payload.ChangeType == ElementChangeAdd && payload.Data != nil {
 		switch payload.Data.(type) {
 		case *model.NodeManagementDetailedDiscoveryDataType:
-			// TODO: manage pending acknowledge
-			_ = payload.Feature.Sender().Subscribe(r.nodeManagement.Address(), r.nodeManagement.Address(), model.FeatureTypeTypeNodeManagement)
+			_ = r.nodeManagement.SubscribeAndWait(payload.Feature)
 
 			// Request Use Case Data
 			_, _ = r.nodeManagement.RequestData(model.FunctionTypeNodeManagementUseCaseData, payload.Feature)

--- a/spine/error.go
+++ b/spine/error.go
@@ -30,6 +30,10 @@ func NewErrorTypeFromString(description string) *ErrorType {
 }
 
 func NewErrorTypeFromResult(result *model.ResultDataType) *ErrorType {
+	if *result.ErrorNumber == model.ErrorNumberTypeNoError {
+		return nil
+	}
+
 	return &ErrorType{
 		ErrorNumber: *result.ErrorNumber,
 		Description: result.Description,

--- a/spine/feature_local.go
+++ b/spine/feature_local.go
@@ -59,7 +59,7 @@ type FeatureLocal interface {
 		function model.FunctionType,
 		destination *FeatureRemoteImpl) (any, *ErrorType)
 	// Subscribes the local feature to the given destination feature; the go routine will block until the response is processed
-	SubscribeAndWait(destination *FeatureRemoteImpl) *ErrorType
+	SubscribeAndWait(remoteDevice *DeviceRemoteImpl, remoteAdress *model.FeatureAddressType) *ErrorType
 	NotifyData(function model.FunctionType, destination *FeatureRemoteImpl) (*model.MsgCounterType, *ErrorType)
 	HandleMessage(message *Message) *ErrorType
 }

--- a/spine/mocks/Sender.go
+++ b/spine/mocks/Sender.go
@@ -95,17 +95,26 @@ func (_m *Sender) ResultSuccess(requestHeader *model.HeaderType, senderAddress *
 }
 
 // Subscribe provides a mock function with given fields: senderAddress, destinationAddress, serverFeatureType
-func (_m *Sender) Subscribe(senderAddress *model.FeatureAddressType, destinationAddress *model.FeatureAddressType, serverFeatureType model.FeatureTypeType) error {
+func (_m *Sender) Subscribe(senderAddress *model.FeatureAddressType, destinationAddress *model.FeatureAddressType, serverFeatureType model.FeatureTypeType) (*model.MsgCounterType, error) {
 	ret := _m.Called(senderAddress, destinationAddress, serverFeatureType)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*model.FeatureAddressType, *model.FeatureAddressType, model.FeatureTypeType) error); ok {
+	var r0 *model.MsgCounterType
+	if rf, ok := ret.Get(0).(func(*model.FeatureAddressType, *model.FeatureAddressType, model.FeatureTypeType) *model.MsgCounterType); ok {
 		r0 = rf(senderAddress, destinationAddress, serverFeatureType)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.MsgCounterType)
+		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*model.FeatureAddressType, *model.FeatureAddressType, model.FeatureTypeType) error); ok {
+		r1 = rf(senderAddress, destinationAddress, serverFeatureType)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // NewSender creates a new instance of Sender. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.

--- a/spine/nodemanagement.go
+++ b/spine/nodemanagement.go
@@ -4,9 +4,18 @@ import (
 	"fmt"
 
 	"github.com/DerAndereAndi/eebus-go/spine/model"
+	"github.com/DerAndereAndi/eebus-go/util"
 )
 
 const NodeManagementFeatureId uint = 0
+
+func NodeManagementAddress(deviceAdress *model.AddressDeviceType) *model.FeatureAddressType {
+	return &model.FeatureAddressType{
+		Entity:  []model.AddressEntityType{0},
+		Feature: util.Ptr(model.AddressFeatureType(NodeManagementFeatureId)),
+		Device:  deviceAdress,
+	}
+}
 
 type NodeManagementImpl struct {
 	*FeatureLocalImpl


### PR DESCRIPTION
The subscribe request is now added to the pending requests to that it can be tracked
Tests are missing until now