### PR TITLE
nodemanagement for remote dev is now always added

### DIFF
--- a/spine/device_local.go
+++ b/spine/device_local.go
@@ -57,9 +57,7 @@ func (r *DeviceLocalImpl) HandleEvent(payload EventPayload) {
 	if payload.EventType == EventTypeDeviceChange && payload.ChangeType == ElementChangeAdd && payload.Data != nil {
 		switch payload.Data.(type) {
 		case *model.NodeManagementDetailedDiscoveryDataType:
-			// TODO: manage pending acknowledge
-			rfAdress := featureAddressType(NodeManagementFeatureId, EntityAddressType(payload.Device.Address(), DeviceInformationAddressEntity))
-			_ = r.nodeManagement.SubscribeAndWait(payload.Device, rfAdress)
+			_ = r.nodeManagement.SubscribeAndWait(payload.Feature.Device(), payload.Feature.Address())
 
 			// Request Use Case Data
 			_, _ = r.nodeManagement.RequestUseCaseData(payload.Device.Address(), payload.Device.Sender())

--- a/spine/device_remote.go
+++ b/spine/device_remote.go
@@ -39,7 +39,7 @@ func NewDeviceRemoteImpl(localDevice *DeviceLocalImpl, ski string, readC <-chan 
 		sender:          sender,
 		heartbeatSender: NewHeartbeatSender(sender),
 	}
-	//res.addNodeManagement()
+	res.addNodeManagement()
 	go res.readPump()
 
 	return &res
@@ -82,11 +82,11 @@ func (d *DeviceRemoteImpl) readPump() {
 	}
 }
 
-// func (d *DeviceRemoteImpl) addNodeManagement() {
-// 	deviceInformation := d.addNewEntity(model.EntityTypeTypeDeviceInformation, NewAddressEntityType([]uint{DeviceInformationEntityId}))
-// 	nodeManagement := NewFeatureRemoteImpl(deviceInformation.NextFeatureId(), deviceInformation, model.FeatureTypeTypeNodeManagement, model.RoleTypeSpecial)
-// 	deviceInformation.AddFeature(nodeManagement)
-// }
+func (d *DeviceRemoteImpl) addNodeManagement() {
+	deviceInformation := d.addNewEntity(model.EntityTypeTypeDeviceInformation, NewAddressEntityType([]uint{DeviceInformationEntityId}))
+	nodeManagement := NewFeatureRemoteImpl(deviceInformation.NextFeatureId(), deviceInformation, model.FeatureTypeTypeNodeManagement, model.RoleTypeSpecial)
+	deviceInformation.AddFeature(nodeManagement)
+}
 
 func (d *DeviceRemoteImpl) Sender() Sender {
 	return d.sender
@@ -182,6 +182,7 @@ func (d *DeviceRemoteImpl) AddEntityAndFeatures(initialData bool, data *model.No
 		}
 
 		entity.SetDescription(ei.Description.Description)
+		entity.RemoveAllFeatures()
 
 		for _, fi := range data.FeatureInformation {
 			if reflect.DeepEqual(fi.Description.FeatureAddress.Entity, entityAddress) {

--- a/spine/entity_remote.go
+++ b/spine/entity_remote.go
@@ -37,3 +37,7 @@ func (r *EntityRemoteImpl) Feature(addressFeature *model.AddressFeatureType) *Fe
 	}
 	return nil
 }
+
+func (r *EntityRemoteImpl) RemoveAllFeatures() {
+	r.features = nil
+}

--- a/spine/events.go
+++ b/spine/events.go
@@ -28,7 +28,7 @@ type EventPayload struct {
 	Device     *DeviceRemoteImpl // required for DetailedDiscovery Call
 	Entity     *EntityRemoteImpl // required for DetailedDiscovery Call and Notify
 	Feature    *FeatureRemoteImpl
-	Data       interface{}
+	Data       any
 }
 
 type EventHandler interface {

--- a/spine/integration_tests/nodemanagement_test.go
+++ b/spine/integration_tests/nodemanagement_test.go
@@ -14,10 +14,12 @@ import (
 )
 
 const (
-	detaileddiscoverydata_send_read_file_prefix  = "./testdata/01_detaileddiscoverydata_send_read"
-	detaileddiscoverydata_recv_reply_file_path   = "./testdata/01_detaileddiscoverydata_recv_reply.json"
-	detaileddiscoverydata_recv_read_file_path    = "./testdata/01_detaileddiscoverydata_recv_read.json"
-	detaileddiscoverydata_send_reply_file_prefix = "./testdata/01_detaileddiscoverydata_send_reply"
+	detaileddiscoverydata_send_read_file_prefix   = "./testdata/01_detaileddiscoverydata_send_read"
+	detaileddiscoverydata_recv_reply_file_path    = "./testdata/01_detaileddiscoverydata_recv_reply.json"
+	detaileddiscoverydata_recv_read_file_path     = "./testdata/01_detaileddiscoverydata_recv_read.json"
+	detaileddiscoverydata_send_reply_file_prefix  = "./testdata/01_detaileddiscoverydata_send_reply"
+	detaileddiscoverydata_recv_read_ack_file_path = "./testdata/01_detaileddiscoverydata_recv_read_ack.json"
+	detaileddiscoverydata_send_result_file_prefix = "./testdata/01_detaileddiscoverydata_send_result"
 )
 
 func TestNodeManagementSuite(t *testing.T) {
@@ -125,7 +127,17 @@ func (s *NodeManagementSuite) TestDetailedDiscovery_RecvReply() {
 }
 
 func (s *NodeManagementSuite) TestDetailedDiscovery_SendReplyWithAcknowledge() {
-	// TODO
+	// irgnore detaileddiscoverydata_send_read
+	<-s.writeC
+
+	// Act
+	s.readC <- loadFileData(s.T(), detaileddiscoverydata_recv_read_ack_file_path)
+
+	// Assert
+	sentReply := <-s.writeC
+	checkSentData(s.T(), sentReply, detaileddiscoverydata_send_reply_file_prefix)
+	sentResult := <-s.writeC
+	checkSentData(s.T(), sentResult, detaileddiscoverydata_send_result_file_prefix)
 }
 
 func loadFileData(t *testing.T, fileName string) []byte {

--- a/spine/integration_tests/testdata/01_detaileddiscoverydata_recv_read_ack.json
+++ b/spine/integration_tests/testdata/01_detaileddiscoverydata_recv_read_ack.json
@@ -1,0 +1,30 @@
+{
+    "datagram": {
+        "header": {
+            "specificationVersion": "1.2.0",
+            "addressSource": {
+                "device": "HEMS",
+                "entity": [
+                    0
+                ],
+                "feature": 0
+            },
+            "addressDestination": {
+                "entity": [
+                    0
+                ],
+                "feature": 0
+            },
+            "msgCounter": 1,
+            "cmdClassifier": "read",
+            "ackRequest":true
+        },
+        "payload": {
+            "cmd": [
+                {
+                    "nodeManagementDetailedDiscoveryData": {}
+                }
+            ]
+        }
+    }
+}

--- a/spine/integration_tests/testdata/01_detaileddiscoverydata_send_result_expected.json
+++ b/spine/integration_tests/testdata/01_detaileddiscoverydata_send_result_expected.json
@@ -1,0 +1,33 @@
+{
+    "datagram": {
+        "header": {
+            "specificationVersion": "1.1.1",
+            "addressSource": {
+                "device": "TestDeviceAddress",
+                "entity": [
+                    0
+                ],
+                "feature": 0
+            },
+            "addressDestination": {
+                "device": "HEMS",
+                "entity": [
+                    0
+                ],
+                "feature": 0
+            },
+            "msgCounter": 3,
+            "msgCounterReference": 1,
+            "cmdClassifier": "result"
+        },
+        "payload": {
+            "cmd": [
+                {
+                    "resultData": {
+                        "errorNumber": 0
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/spine/nodemanagement_defaileddiscovery.go
+++ b/spine/nodemanagement_defaileddiscovery.go
@@ -10,7 +10,10 @@ import (
 // request detailed discovery data from a remote device
 func (r *NodeManagementImpl) RequestDetailedDiscovery(remoteDeviceAddress *model.AddressDeviceType, sender Sender) (*model.MsgCounterType, *ErrorType) {
 	rfAdress := featureAddressType(NodeManagementFeatureId, EntityAddressType(remoteDeviceAddress, DeviceInformationAddressEntity))
-	return r.RequestDataBySenderAddress(model.FunctionTypeNodeManagementDetailedDiscoveryData, sender, rfAdress, defaultMaxResponseDelay)
+	cmd := model.CmdType{
+		NodeManagementDetailedDiscoveryData: &model.NodeManagementDetailedDiscoveryDataType{},
+	}
+	return r.RequestDataBySenderAddress(cmd, sender, rfAdress, defaultMaxResponseDelay)
 }
 
 // handle incoming detailed discovery read call
@@ -65,6 +68,7 @@ func (r *NodeManagementImpl) replyDetailedDiscoveryData(message *Message, data *
 		EventType:  EventTypeDeviceChange,
 		ChangeType: ElementChangeAdd,
 		Device:     remoteDevice,
+		Feature:    message.FeatureRemote,
 		Data:       data,
 	}
 	Events.Publish(payload)

--- a/spine/nodemanagement_usecase.go
+++ b/spine/nodemanagement_usecase.go
@@ -9,7 +9,10 @@ import (
 
 func (r *NodeManagementImpl) RequestUseCaseData(remoteDeviceAddress *model.AddressDeviceType, sender Sender) (*model.MsgCounterType, *ErrorType) {
 	rfAdress := featureAddressType(NodeManagementFeatureId, EntityAddressType(remoteDeviceAddress, DeviceInformationAddressEntity))
-	return r.RequestDataBySenderAddress(model.FunctionTypeNodeManagementUseCaseData, sender, rfAdress, defaultMaxResponseDelay)
+	cmd := model.CmdType{
+		NodeManagementUseCaseData: &model.NodeManagementUseCaseDataType{},
+	}
+	return r.RequestDataBySenderAddress(cmd, sender, rfAdress, defaultMaxResponseDelay)
 }
 
 func (r *NodeManagementImpl) readUseCaseData(featureRemote *FeatureRemoteImpl, requestHeader *model.HeaderType) error {


### PR DESCRIPTION
Das NodeManagement wird nun sofort beim Anlegen des RemoteDevice erzeugt noch bevor das DetailedDiscovery durchgeführt wird. Somit lässt sich die Implementierung vereinfachen. 
Ausserdem werden nun DetailedDiscovery Requests mit Acknowledge korrekt verarbeitet.
@DerAndereAndi Bitte schaue dir die Änderungen an, da ich ein paar Änderungen von dir aus dem PR  #7   wieder rückgängig gemacht habe.