### PR TITLE
Pass the featureset on setup

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -41,6 +41,9 @@ type ServiceDescription struct {
 	// The EEBUS device type of the device model, required
 	DeviceType model.DeviceTypeType
 
+	// The EEBUS device network feature set type, required
+	FeatureSet model.NetworkManagementFeatureSetType
+
 	// Serial number of the device, required
 	SerialNumber string
 
@@ -148,6 +151,7 @@ func (s *EEBUSService) Setup() error {
 		sd.SerialNumber,
 		deviceAdress,
 		sd.DeviceType,
+		sd.FeatureSet,
 	)
 
 	// Create the device entity and add it to the SPINE device

--- a/spine/device.go
+++ b/spine/device.go
@@ -12,7 +12,7 @@ type DeviceImpl struct {
 // Initialize a new device
 // Both values are required for a local device but provided as empty strings for a remote device
 // as the address is only provided via detailed discovery response
-func NewDeviceImpl(address *model.AddressDeviceType, dType *model.DeviceTypeType) *DeviceImpl {
+func NewDeviceImpl(address *model.AddressDeviceType, dType *model.DeviceTypeType, featureSet *model.NetworkManagementFeatureSetType) *DeviceImpl {
 	deviceImpl := &DeviceImpl{
 		useCaseManager: NewUseCaseManager(),
 	}
@@ -23,6 +23,10 @@ func NewDeviceImpl(address *model.AddressDeviceType, dType *model.DeviceTypeType
 
 	if address != nil {
 		deviceImpl.address = address
+	}
+
+	if featureSet != nil {
+		deviceImpl.featureSet = featureSet
 	}
 
 	return deviceImpl

--- a/spine/device_local.go
+++ b/spine/device_local.go
@@ -23,10 +23,16 @@ type DeviceLocalImpl struct {
 	serialNumber string
 }
 
-func NewDeviceLocalImpl(brandName, deviceModel, deviceCode, serialNumber, deviceAddress string, deviceType model.DeviceTypeType) *DeviceLocalImpl {
+func NewDeviceLocalImpl(brandName, deviceModel, deviceCode, serialNumber, deviceAddress string, deviceType model.DeviceTypeType, featureSet model.NetworkManagementFeatureSetType) *DeviceLocalImpl {
 	address := model.AddressDeviceType(deviceAddress)
+
+	var fSet *model.NetworkManagementFeatureSetType
+	if len(featureSet) != 0 {
+		fSet = &featureSet
+	}
+
 	res := &DeviceLocalImpl{
-		DeviceImpl:          NewDeviceImpl(&address, &deviceType),
+		DeviceImpl:          NewDeviceImpl(&address, &deviceType, fSet),
 		subscriptionManager: NewSubscriptionManager(),
 		remoteDevices:       make(map[string]*DeviceRemoteImpl),
 		brandName:           brandName,
@@ -35,8 +41,6 @@ func NewDeviceLocalImpl(brandName, deviceModel, deviceCode, serialNumber, device
 		serialNumber:        serialNumber,
 	}
 
-	// pass in featureSet as an argument ??
-	res.featureSet = util.Ptr(model.NetworkManagementFeatureSetTypeSmart)
 	res.addDeviceInformation()
 	return res
 }

--- a/spine/device_remote.go
+++ b/spine/device_remote.go
@@ -31,7 +31,7 @@ type DeviceRemoteImpl struct {
 func NewDeviceRemoteImpl(localDevice *DeviceLocalImpl, ski string, readC <-chan []byte, writeC chan<- []byte) *DeviceRemoteImpl {
 	sender := NewSender(writeC)
 	res := DeviceRemoteImpl{
-		DeviceImpl:      NewDeviceImpl(nil, nil),
+		DeviceImpl:      NewDeviceImpl(nil, nil, nil),
 		ski:             ski,
 		localDevice:     localDevice,
 		readChannel:     readC,

--- a/spine/feature_local_test.go
+++ b/spine/feature_local_test.go
@@ -124,7 +124,7 @@ func (suite *DeviceClassificationTestSuite) TestDeviceClassification_Request_Err
 }
 
 func CreateLocalDeviceAndFeature(entityId uint, featureType model.FeatureTypeType, role model.RoleType) *spine.FeatureLocalImpl {
-	localDevice := spine.NewDeviceLocalImpl("Vendor", "DeviceName", "DeviceCode", "SerialNumber", "Address", model.DeviceTypeTypeEnergyManagementSystem)
+	localDevice := spine.NewDeviceLocalImpl("Vendor", "DeviceName", "DeviceCode", "SerialNumber", "Address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart)
 	localEntity := spine.NewEntityLocalImpl(localDevice, model.EntityTypeTypeEVSE, []model.AddressEntityType{model.AddressEntityType(entityId)})
 	localDevice.AddEntity(localEntity)
 	localFeature := spine.NewFeatureLocalImpl(localEntity.NextFeatureId(), localEntity, featureType, role)

--- a/spine/feature_remote_test.go
+++ b/spine/feature_remote_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func CreateRemoteDeviceAndFeature(entityId uint, featureType model.FeatureTypeType, role model.RoleType, sender Sender) *FeatureRemoteImpl {
-	localDevice := NewDeviceLocalImpl("Vendor", "DeviceName", "DeviceCode", "SerialNumber", "Address", model.DeviceTypeTypeEnergyManagementSystem)
+	localDevice := NewDeviceLocalImpl("Vendor", "DeviceName", "DeviceCode", "SerialNumber", "Address", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart)
 
 	remoteDevice := NewDeviceRemoteImpl(localDevice, "ski", nil, nil)
 	remoteDevice.address = util.Ptr(model.AddressDeviceType("Address"))

--- a/spine/integration_tests/nodemanagement_test.go
+++ b/spine/integration_tests/nodemanagement_test.go
@@ -43,7 +43,7 @@ func (s *NodeManagementSuite) SetupSuite() {
 
 func (s *NodeManagementSuite) BeforeTest(suiteName, testName string) {
 	s.sut = spine.NewDeviceLocalImpl("TestBrandName", "TestDeviceModel", "TestDeviceCode",
-		"TestSerialNumber", "TestDeviceAddress", model.DeviceTypeTypeChargingStation)
+		"TestSerialNumber", "TestDeviceAddress", model.DeviceTypeTypeChargingStation, model.NetworkManagementFeatureSetTypeSmart)
 	s.remoteSki = "TestRemoteSki"
 
 	s.readC = make(chan []byte, 1)


### PR DESCRIPTION
On service setup the NetworkManagementFeatureSetType needs to be set via the ServiceDescription and will then be passed on.