### PR TITLE
Connection and mDNS improvements

### DIFF
--- a/cmd/evse/main.go
+++ b/cmd/evse/main.go
@@ -83,7 +83,7 @@ func (h *evse) run() {
 	remoteService := service.ServiceDetails{
 		SKI: remoteSki,
 	}
-	_ = h.myService.RegisterRemoteService(remoteService)
+	h.myService.RegisterRemoteService(remoteService)
 }
 
 // handle a request to trust a remote service

--- a/cmd/hems/main.go
+++ b/cmd/hems/main.go
@@ -82,7 +82,7 @@ func (h *hems) run() {
 	remoteService := service.ServiceDetails{
 		SKI: remoteSki,
 	}
-	_ = h.myService.RegisterRemoteService(remoteService)
+	h.myService.RegisterRemoteService(remoteService)
 }
 
 // EEBUSServiceDelegate

--- a/go.mod
+++ b/go.mod
@@ -22,12 +22,10 @@ require (
 	github.com/godbus/dbus/v5 v5.0.4
 	github.com/gorilla/websocket v1.5.0
 	github.com/holoplot/go-avahi v1.0.0
-	github.com/libp2p/zeroconf/v2 v2.0.0-00010101000000-000000000000
+	github.com/libp2p/zeroconf/v2 v2.0.0-20220623102032-af1f1d3ada85
 	github.com/rickb777/date v1.19.1
 	github.com/stretchr/testify v1.7.1
 	gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a
 )
-
-replace github.com/libp2p/zeroconf/v2 => github.com/DerAndereAndi/zeroconf/v2 v2.0.0-20220607195515-4c9557651bc9
 
 replace github.com/holoplot/go-avahi => github.com/DerAndereAndi/go-avahi v0.0.0-20220623134409-61c3cd3f6dd4

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,9 @@ require (
 
 require (
 	github.com/ahmetb/go-linq/v3 v3.2.0
+	github.com/godbus/dbus/v5 v5.0.4
 	github.com/gorilla/websocket v1.5.0
+	github.com/holoplot/go-avahi v1.0.0
 	github.com/libp2p/zeroconf/v2 v2.0.0-00010101000000-000000000000
 	github.com/rickb777/date v1.19.1
 	github.com/stretchr/testify v1.7.1
@@ -27,3 +29,5 @@ require (
 )
 
 replace github.com/libp2p/zeroconf/v2 => github.com/DerAndereAndi/zeroconf/v2 v2.0.0-20220607195515-4c9557651bc9
+
+replace github.com/holoplot/go-avahi => github.com/DerAndereAndi/go-avahi v0.0.0-20220623134409-61c3cd3f6dd4

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/DerAndereAndi/go-avahi v0.0.0-20220623134409-61c3cd3f6dd4 h1:CIcZ9WJ+NUps1TAEn/buzixARV+ApvwYJUes5/oXDpI=
 github.com/DerAndereAndi/go-avahi v0.0.0-20220623134409-61c3cd3f6dd4/go.mod h1:qH5psEKb0DK+BRplMfc+RY4VMOlbf6mqfxgpMy6aP0M=
-github.com/DerAndereAndi/zeroconf/v2 v2.0.0-20220607195515-4c9557651bc9 h1:xM6uz9OcnqJ+Tu8h3LFgYdg3gy3Qu1eg2UbrL8LuPyY=
-github.com/DerAndereAndi/zeroconf/v2 v2.0.0-20220607195515-4c9557651bc9/go.mod h1:fuJqLnUwZTshS3U/bMRJ3+ow/v9oid1n0DmyYyNO1Xs=
 github.com/ahmetb/go-linq/v3 v3.2.0 h1:BEuMfp+b59io8g5wYzNoFe9pWPalRklhlhbiU3hYZDE=
 github.com/ahmetb/go-linq/v3 v3.2.0/go.mod h1:haQ3JfOeWK8HpVxMtHHEMPVgBKiYyQ+f1/kLZh/cj9U=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -13,6 +11,8 @@ github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/libp2p/zeroconf/v2 v2.0.0-20220623102032-af1f1d3ada85 h1:jIPip1x91RFdohBowS6pg0lDWoFL8ZqL6ix3NjoCuF4=
+github.com/libp2p/zeroconf/v2 v2.0.0-20220623102032-af1f1d3ada85/go.mod h1:fuJqLnUwZTshS3U/bMRJ3+ow/v9oid1n0DmyYyNO1Xs=
 github.com/miekg/dns v1.1.43/go.mod h1:+evo5L0630/F6ca/Z9+GAqzhjGyn8/c+TBaOyfEl0V4=
 github.com/miekg/dns v1.1.49 h1:qe0mQU3Z/XpFeE+AEBo2rqaS1IPBJ3anmqZ4XiZJVG8=
 github.com/miekg/dns v1.1.49/go.mod h1:e3IlAVfNqAllflbibAZEWOXOQ+Ynzk/dDozDxY7XnME=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/DerAndereAndi/go-avahi v0.0.0-20220623134409-61c3cd3f6dd4 h1:CIcZ9WJ+NUps1TAEn/buzixARV+ApvwYJUes5/oXDpI=
+github.com/DerAndereAndi/go-avahi v0.0.0-20220623134409-61c3cd3f6dd4/go.mod h1:qH5psEKb0DK+BRplMfc+RY4VMOlbf6mqfxgpMy6aP0M=
 github.com/DerAndereAndi/zeroconf/v2 v2.0.0-20220607195515-4c9557651bc9 h1:xM6uz9OcnqJ+Tu8h3LFgYdg3gy3Qu1eg2UbrL8LuPyY=
 github.com/DerAndereAndi/zeroconf/v2 v2.0.0-20220607195515-4c9557651bc9/go.mod h1:fuJqLnUwZTshS3U/bMRJ3+ow/v9oid1n0DmyYyNO1Xs=
 github.com/ahmetb/go-linq/v3 v3.2.0 h1:BEuMfp+b59io8g5wYzNoFe9pWPalRklhlhbiU3hYZDE=
@@ -5,6 +7,8 @@ github.com/ahmetb/go-linq/v3 v3.2.0/go.mod h1:haQ3JfOeWK8HpVxMtHHEMPVgBKiYyQ+f1/
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/godbus/dbus/v5 v5.0.4 h1:9349emZab16e7zQvpmsbtjc18ykshndd8y2PG3sgJbA=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=

--- a/service/connection.go
+++ b/service/connection.go
@@ -107,7 +107,6 @@ func (c *ConnectionHandler) startup() {
 	go c.writeShipPump()
 
 	go func() {
-		fmt.Println("12")
 		if err := c.shipHandshake(c.remoteService.userTrust || len(c.remoteService.ShipID) > 0); err != nil {
 			fmt.Println("SHIP handshake error: ", err)
 			c.shutdown(false)

--- a/service/hub.go
+++ b/service/hub.go
@@ -92,12 +92,6 @@ func (h *connectionsHub) start() {
 
 // handle (dis-)connecting remote services
 func (h *connectionsHub) run() {
-	go func() {
-		details := ServiceDetails{
-			SKI: "c7faf5f2edd3131e0f2e8649e38983c620886de6",
-		}
-		_ = h.connectFoundService(details, "192.168.1.146", "4712")
-	}()
 	for {
 		select {
 		// connect to a paired service

--- a/service/hub.go
+++ b/service/hub.go
@@ -132,11 +132,13 @@ func (h *connectionsHub) run() {
 					h.mux.Unlock()
 				}
 			}
-			// startup mDNS if this is not a CEM and a paired service is not connected
-			if c.localService.deviceType != model.DeviceTypeTypeEnergyManagementSystem &&
-				len(h.connections) == 0 && len(h.registeredServices) > 0 {
+			// startup mDNS if a paired service is not connected
+			if len(h.connections) == 0 && len(h.registeredServices) > 0 {
 				fmt.Println("Starting mDNS")
-				_ = h.mdns.Announce()
+				// if this is not a CEM also start the mDNS announcement
+				if c.localService.deviceType != model.DeviceTypeTypeEnergyManagementSystem {
+					_ = h.mdns.Announce()
+				}
 				h.mdns.RegisterMdnsSearch(h)
 			}
 		}

--- a/service/hub.go
+++ b/service/hub.go
@@ -274,7 +274,7 @@ func (h *connectionsHub) connectFoundService(remoteService *ServiceDetails, host
 		return nil
 	}
 
-	fmt.Println("Initiating connection to ", remoteService.SKI)
+	fmt.Println("Initiating connection to", remoteService.SKI)
 
 	dialer := &websocket.Dialer{
 		Proxy:            http.ProxyFromEnvironment,
@@ -324,6 +324,8 @@ func (h *connectionsHub) connectFoundService(remoteService *ServiceDetails, host
 }
 
 func (h *connectionsHub) registeredServiceForSKI(ski string) (*ServiceDetails, error) {
+	h.mux.Lock()
+	defer h.mux.Unlock()
 	for _, service := range h.registeredServices {
 		if service.SKI == ski {
 			return &service, nil

--- a/service/mdns.go
+++ b/service/mdns.go
@@ -236,7 +236,17 @@ func (m *mdns) shutdown() {
 
 // Register a callback to be invoked for found mDNS entries
 func (m *mdns) RegisterMdnsSearch(cb MdnsSearch) {
-	m.searchDelegates = append(m.searchDelegates, cb)
+	// check if callback is already registered
+	registered := false
+	for _, c := range m.searchDelegates {
+		if c == cb {
+			registered = true
+		}
+	}
+
+	if !registered {
+		m.searchDelegates = append(m.searchDelegates, cb)
+	}
 
 	m.mux.Lock()
 	defer m.mux.Unlock()

--- a/service/mdns.go
+++ b/service/mdns.go
@@ -305,7 +305,7 @@ func (m *mdns) resolveEntries() {
 				ctx.Done()
 			case service := <-zcEntries:
 				// Zeroconf has issues with merging mDNS data and sometimes reports non complety records
-				if len(service.Text) == 0 || len(service.AddrIPv4) == 0 {
+				if len(service.Text) == 0 {
 					continue
 				}
 

--- a/service/mdns.go
+++ b/service/mdns.go
@@ -1,0 +1,488 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/holoplot/go-avahi"
+	"github.com/libp2p/zeroconf/v2"
+)
+
+type MdnsEntry struct {
+	Name       string
+	Identifier string   // mandatory
+	Path       string   // mandatory
+	Register   bool     // mandatory
+	Brand      string   // optional
+	Type       string   // optional
+	Model      string   // optional
+	Host       string   // mandatory
+	Port       int      // mandatory
+	Addresses  []net.IP // mandatory
+}
+
+type MdnsSearch interface {
+	ReportMdnsEntries(entries map[string]MdnsEntry)
+}
+
+type mdns struct {
+	serviceDescription *ServiceDescription
+	ski                string
+
+	isAnnounced         bool
+	isSearchingServices bool
+
+	cancelChan chan bool
+
+	// the currently available mDNS entries with the SKI as the key in the map
+	entries map[string]MdnsEntry
+
+	// the registered callbacks
+	searchDelegates []MdnsSearch
+
+	// The zeroconf service for mDNS related tasks
+	zc *zeroconf.Server
+
+	// The alternative avahi mDNS service
+	av           *avahi.Server
+	avEntryGroup *avahi.EntryGroup
+}
+
+func newMDNS(ski string, serviceDescription *ServiceDescription) (*mdns, error) {
+	m := &mdns{
+		ski:                ski,
+		serviceDescription: serviceDescription,
+		entries:            make(map[string]MdnsEntry),
+		cancelChan:         make(chan bool),
+	}
+
+	if av, err := m.setupAvahi(); err == nil {
+		m.av = av
+	}
+
+	// on startup always start mDNS announcement
+	if err := m.Announce(); err != nil {
+		return nil, err
+	}
+
+	// catch signals
+	go func() {
+		signalC := make(chan os.Signal, 1)
+		signal.Notify(signalC, os.Interrupt, syscall.SIGTERM)
+
+		<-signalC // wait for signal
+
+		m.Unannounce()
+	}()
+
+	return m, nil
+}
+
+// setup avahi for mDNS
+func (m *mdns) setupAvahi() (*avahi.Server, error) {
+	dbusConn, err := dbus.SystemBus()
+	if err != nil {
+		return nil, err
+	}
+
+	avahiServer, err := avahi.ServerNew(dbusConn)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := avahiServer.GetAPIVersion(); err != nil {
+		return nil, err
+	}
+
+	return avahiServer, nil
+}
+
+// Return allowed interfaces for mDNS
+func (m *mdns) interfaces() ([]net.Interface, []int32, error) {
+	var ifaces []net.Interface
+	var ifaceIndexes []int32
+
+	if len(m.serviceDescription.Interfaces) > 0 {
+		ifaces = make([]net.Interface, len(m.serviceDescription.Interfaces))
+		for i, ifaceName := range m.serviceDescription.Interfaces {
+			iface, err := net.InterfaceByName(ifaceName)
+			if err != nil {
+				return nil, nil, err
+			}
+			ifaces[i] = *iface
+			ifaceIndexes[i] = int32(iface.Index)
+		}
+	}
+
+	if len(ifaces) == 0 {
+		ifaces = nil
+		ifaceIndexes = []int32{avahi.InterfaceUnspec}
+	}
+
+	return ifaces, ifaceIndexes, nil
+}
+
+// Announces the service to the network via mDNS
+// A CEM service should always invoke this on startup
+// Any other service should only invoke this whenever it is not connected to a CEM service
+func (m *mdns) Announce() error {
+	if m.isAnnounced {
+		return nil
+	}
+
+	ifaces, ifaceIndexes, err := m.interfaces()
+	if err != nil {
+		return err
+	}
+
+	serviceIdentifier := fmt.Sprintf("%s-%s-%s", m.serviceDescription.Brand, m.serviceDescription.Model, m.serviceDescription.SerialNumber)
+	if len(m.serviceDescription.Identifier) > 0 {
+		serviceIdentifier = m.serviceDescription.Identifier
+	}
+
+	txt := []string{ // SHIP 7.3.2
+		"txtvers=1",
+		"path=" + shipWebsocketPath,
+		"id=" + serviceIdentifier,
+		"ski=" + m.ski,
+		"brand=" + m.serviceDescription.Brand,
+		"model=" + m.serviceDescription.Model,
+		"type=" + string(m.serviceDescription.DeviceType),
+		"register=" + fmt.Sprintf("%v", m.serviceDescription.RegisterAutoAccept),
+	}
+
+	fmt.Println("mDNS: Announce")
+
+	if m.av == nil {
+		// use Zeroconf library if avahi is not available
+		if mDNSServer, err := zeroconf.Register(serviceIdentifier, shipZeroConfServiceType, shipZeroConfDomain, m.serviceDescription.Port, txt, ifaces); err == nil {
+			m.zc = mDNSServer
+
+			m.isAnnounced = true
+			return nil
+		}
+
+		return err
+	}
+
+	// avahi
+	entryGroup, err := m.av.EntryGroupNew()
+	if err != nil {
+		return err
+	}
+
+	var btxt [][]byte
+	for _, t := range txt {
+		btxt = append(btxt, []byte(t))
+	}
+
+	for _, iface := range ifaceIndexes {
+		err = entryGroup.AddService(iface, avahi.ProtoUnspec, 0, serviceIdentifier, shipZeroConfServiceType, shipZeroConfDomain, "", uint16(m.serviceDescription.Port), btxt)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = entryGroup.Commit()
+	if err != nil {
+		return err
+	}
+
+	m.avEntryGroup = entryGroup
+	m.isAnnounced = true
+
+	return nil
+}
+
+// Stop the mDNS announcement on the network
+func (m *mdns) Unannounce() {
+	if !m.isAnnounced {
+		return
+	}
+
+	if m.zc != nil {
+		m.zc.Shutdown()
+		m.zc = nil
+	}
+	if m.av != nil {
+		m.av.EntryGroupFree(m.avEntryGroup)
+		m.avEntryGroup = nil
+	}
+	fmt.Println("mDNS: Stop announcement")
+
+	m.isAnnounced = false
+}
+
+// Shutdown all of mDNS
+func (m *mdns) shutdown() {
+	m.Unannounce()
+
+	if m.av != nil {
+		m.av.Close()
+		m.av = nil
+	}
+
+	m.stopResolvingEntries()
+}
+
+// Register a callback to be invoked for found mDNS entries
+func (m *mdns) RegisterMdnsSearch(cb MdnsSearch) {
+	m.searchDelegates = append(m.searchDelegates, cb)
+
+	if !m.isSearchingServices {
+		fmt.Println("mDNS: Start search")
+		go m.resolveEntries()
+	}
+}
+
+// Remove a callback for found mDNS entries and stop searching if no callbacks are left
+func (m *mdns) UnregisterMdnsSearch(cb MdnsSearch) {
+	var delegates []MdnsSearch
+
+	for _, item := range m.searchDelegates {
+		if item != cb {
+			delegates = append(delegates, cb)
+		}
+	}
+
+	m.searchDelegates = delegates
+
+	if len(m.searchDelegates) == 0 {
+		m.stopResolvingEntries()
+	}
+}
+
+// search for mDNS entries and report them
+// to be invoked in a background thread!
+func (m *mdns) resolveEntries() {
+	// for Zeroconf we need a context
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var err error
+	var avBrowser *avahi.ServiceBrowser
+
+	zcEntries := make(chan *zeroconf.ServiceEntry)
+	defer close(zcEntries)
+
+	if m.av != nil {
+		// instead of limiting search on specific allowed interfaces, we allow all and filter the results
+		if avBrowser, err = m.av.ServiceBrowserNew(avahi.InterfaceUnspec, avahi.ProtoUnspec, shipZeroConfServiceType, shipZeroConfDomain, 0); err != nil {
+			return
+		}
+	} else {
+		go func() {
+			_ = zeroconf.Browse(ctx, shipZeroConfServiceType, shipZeroConfDomain, zcEntries)
+		}()
+	}
+
+	m.isSearchingServices = true
+
+	var end bool
+	for !end {
+		if m.av != nil {
+			select {
+			case <-m.cancelChan:
+				end = true
+				break
+			case service := <-avBrowser.AddChannel:
+				m.processAvahiService(service, false)
+			case service := <-avBrowser.RemoveChannel:
+				m.processAvahiService(service, true)
+			}
+		} else {
+			select {
+			case <-ctx.Done():
+				end = true
+				break
+			case <-m.cancelChan:
+				ctx.Done()
+			case service := <-zcEntries:
+				// Zeroconf has issues with merging mDNS data and sometimes reports non complety records
+				if len(service.Text) == 0 || len(service.AddrIPv4) == 0 {
+					continue
+				}
+
+				elements := m.parseTxt(service.Text)
+
+				addresses := service.AddrIPv4
+				// Only use IPv4 for now
+				// addresses = append(addresses, service.AddrIPv6...)
+				m.processMdnsEntry(elements, service.Instance, service.HostName, addresses, service.Port, false)
+			}
+		}
+	}
+
+	if m.av != nil {
+		m.av.ServiceBrowserFree(avBrowser)
+	}
+
+	m.isSearchingServices = false
+}
+
+// stop searching for mDNS entries
+func (m *mdns) stopResolvingEntries() {
+	if m.cancelChan != nil {
+		fmt.Println("mDNS: stop search")
+
+		m.cancelChan <- true
+	}
+}
+
+// process an avahi mDNS service
+// as avahi returns a service per interface, we need to combine them
+func (m *mdns) processAvahiService(service avahi.Service, remove bool) {
+	_, ifaceIndexes, err := m.interfaces()
+	if err != nil {
+		fmt.Println("Error getting interfaces:", err)
+		return
+	}
+
+	// check if the service is within the allowed list
+	allow := false
+	if len(ifaceIndexes) == 1 && ifaceIndexes[0] == avahi.InterfaceUnspec {
+		allow = true
+	} else {
+		for _, iface := range ifaceIndexes {
+			if service.Interface == iface {
+				allow = true
+				break
+			}
+		}
+	}
+
+	if !allow {
+		return
+	}
+
+	resolved, err := m.av.ResolveService(service.Interface, service.Protocol, service.Name, service.Type, service.Domain, avahi.ProtoUnspec, 0)
+	if err != nil {
+		return
+	}
+
+	// convert [][]byte to []string manually
+	var txt []string
+	for _, element := range resolved.Txt {
+		txt = append(txt, string(element))
+	}
+	elements := m.parseTxt(txt)
+
+	// convert address to net.IP
+	address := net.ParseIP(resolved.Address)
+	// if the address can not be used, ignore the entry
+	if address == nil || address.IsUnspecified() {
+		return
+	}
+
+	// Ignore IPv6 addresses for now
+	if address.To4() == nil {
+		return
+	}
+
+	m.processMdnsEntry(elements, resolved.Name, resolved.Host, []net.IP{address}, int(resolved.Port), remove)
+}
+
+// parse mDNS text fields
+func (m *mdns) parseTxt(txt []string) map[string]string {
+	result := make(map[string]string)
+
+	for _, item := range txt {
+		s := strings.Split(item, "=")
+		if len(s) != 2 {
+			continue
+		}
+		result[s[0]] = s[1]
+	}
+
+	return result
+}
+
+// process an mDNS entry and manage mDNS entries map
+func (m *mdns) processMdnsEntry(elements map[string]string, name, host string, addresses []net.IP, port int, remove bool) {
+	// check for mandatory text elements
+	mapItems := []string{"txtvers", "id", "path", "ski", "register"}
+	for _, item := range mapItems {
+		if _, ok := elements[item]; !ok {
+			return
+		}
+	}
+
+	txtvers := elements["txtvers"]
+	// value of mandatory txtvers has to be 1 or the response be ignored: SHIP 7.3.2
+	if txtvers != "1" {
+		return
+	}
+
+	identifier := elements["id"]
+	path := elements["path"]
+	ski := elements["ski"]
+
+	// ignore own service
+	if ski == m.ski {
+		return
+	}
+
+	register := elements["register"]
+	// register has to be a boolean
+	if register != "true" && register != "false" {
+		return
+	}
+
+	var deviceType, model, brand string
+
+	if _, ok := elements["brand"]; ok {
+		brand = elements["brand"]
+	}
+	if _, ok := elements["type"]; ok {
+		deviceType = elements["type"]
+	}
+	if _, ok := elements["model"]; ok {
+		model = elements["model"]
+	}
+
+	_, exists := m.entries[ski]
+
+	if remove && exists {
+		// remove
+		// there will be a remove for each address with avahi, but we'll delete it right away
+		delete(m.entries, ski)
+	} else if exists {
+		// update
+		// avahi sends an item for each network address, merge them
+		entry := m.entries[ski]
+
+		// we assume only network addresses are added
+		entry.Addresses = append(entry.Addresses, addresses...)
+
+		m.entries[ski] = entry
+	} else if !exists && !remove {
+		// new
+		newEntry := MdnsEntry{
+			Name:       name,
+			Identifier: identifier,
+			Path:       path,
+			Register:   register == "true",
+			Brand:      brand,
+			Type:       deviceType,
+			Model:      model,
+			Host:       host,
+			Port:       port,
+			Addresses:  addresses,
+		}
+		m.entries[ski] = newEntry
+
+		fmt.Println("SKI:", ski, "Name:", name, "Brand:", brand, "Model:", model, "Typ:", deviceType, "Identifier:", identifier, "Register:", register)
+	} else {
+		return
+	}
+
+	for _, cb := range m.searchDelegates {
+		cb.ReportMdnsEntries(m.entries)
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -14,7 +14,7 @@ const defaultPort int = 4711
 
 type ServiceDetails struct {
 	// This is the SKI of the service
-	// This needs to be peristed
+	// This needs to be persisted
 	SKI string
 
 	// ShipID is the ship identifier of the service
@@ -169,7 +169,12 @@ func (s *EEBUSService) Setup() error {
 	s.spineLocalDevice.AddEntity(entity)
 
 	// Setup connections hub with mDNS and websocket connection handling
-	s.connectionsHub = newConnectionsHub(s.ServiceDescription, s.LocalService, s)
+	hub, err := newConnectionsHub(s.ServiceDescription, s.LocalService, s)
+	if err != nil {
+		return err
+	}
+
+	s.connectionsHub = hub
 
 	return nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -244,8 +244,8 @@ func (s *EEBUSService) RemoteDeviceOfType(deviceType model.DeviceTypeType) *spin
 
 // Adds a new device to the list of known devices which can be connected to
 // and connect it if it is currently not connected
-func (s *EEBUSService) RegisterRemoteService(service ServiceDetails) error {
-	return s.connectionsHub.registerRemoteService(service)
+func (s *EEBUSService) RegisterRemoteService(service ServiceDetails) {
+	s.connectionsHub.registerRemoteService(service)
 }
 
 // Remove a device from the list of known devices which can be connected to

--- a/service/util/helper.go
+++ b/service/util/helper.go
@@ -8,6 +8,16 @@ import (
 	"gitlab.com/c0b/go-ordered-json"
 )
 
+// check if a provided channel is closed
+func IsChannelClosed[T any](ch <-chan T) bool {
+	select {
+	case <-ch:
+		return false
+	default:
+		return true
+	}
+}
+
 // convert incoming EEBUS json format into standard json format
 func JsonFromEEBUSJson(json []byte) []byte {
 	var result = bytes.ReplaceAll(json, []byte("[{"), []byte("{"))


### PR DESCRIPTION
- Re-added avahi which is more reliable on Linux than zeroconf
- Use an go-avahi fork, with some critical fixes
- Abstraced zeroconf and avahi into mdns
- Added interface for the connectionsHub and the actual service implementation to be able to receive mDNS search results
- mDNS search results will run only while paired services are not connected, if the service is an EMS or if it is triggered by the service implementation, e.g. when wanting to display the available services on the network in a UI to pair them
- mDNS announcement is only done when the service is an EMS or if no EMS is paired or the paired EMS is not connected
- automatically tries to connect via the host name and all reported IP addresses, until connection was established or all where tried
- ignore IPv6 addresses in mDNS records for now
- remove temporary test code that was accidentally committed