### PR TITLE
partial updates implementation by using interfaces

### DIFF
--- a/spine/feature_remote.go
+++ b/spine/feature_remote.go
@@ -40,9 +40,8 @@ func (r *FeatureRemoteImpl) Data(function model.FunctionType) any {
 	return r.functionData(function).DataAny()
 }
 
-func (r *FeatureRemoteImpl) SetData(function model.FunctionType, data any) {
-	r.functionData(function).SetDataAny(data)
-
+func (r *FeatureRemoteImpl) UpdateData(function model.FunctionType, data any, filterPartial *model.FilterType, filterDelete *model.FilterType) {
+	r.functionData(function).UpdateDataAny(data, filterPartial, filterDelete)
 	// TODO: fire event
 }
 

--- a/spine/function_data_cmd_test.go
+++ b/spine/function_data_cmd_test.go
@@ -26,7 +26,7 @@ func (suite *FunctionDataCmdTestSuite) SetupSuite() {
 		DeviceName: util.Ptr(model.DeviceClassificationStringType("device name")),
 	}
 	suite.sut = NewFunctionDataCmd[model.DeviceClassificationManufacturerDataType](suite.function)
-	suite.sut.SetData(suite.data)
+	suite.sut.UpdateData(suite.data, nil, nil)
 }
 
 func (suite *FunctionDataCmdTestSuite) TestFunctionDataCmd_ReadCmd() {

--- a/spine/function_data_test.go
+++ b/spine/function_data_test.go
@@ -8,16 +8,62 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFunctionData(t *testing.T) {
-
-	setData := &model.DeviceClassificationManufacturerDataType{
+func TestFunctionData_UpdateData(t *testing.T) {
+	newData := &model.DeviceClassificationManufacturerDataType{
 		DeviceName: util.Ptr(model.DeviceClassificationStringType("device name")),
 	}
 	functionType := model.FunctionTypeDeviceClassificationManufacturerData
 	sut := NewFunctionData[model.DeviceClassificationManufacturerDataType](functionType)
-	sut.SetData(setData)
+	sut.UpdateData(newData, nil, nil)
 	getData := sut.Data()
 
-	assert.Equal(t, setData.DeviceName, getData.DeviceName)
+	assert.Equal(t, newData.DeviceName, getData.DeviceName)
 	assert.Equal(t, functionType, sut.Function())
+}
+
+func TestFunctionData_UpdateDataPartial(t *testing.T) {
+	newData := &model.ElectricalConnectionPermittedValueSetListDataType{
+		ElectricalConnectionPermittedValueSetData: []model.ElectricalConnectionPermittedValueSetDataType{
+			{
+				ElectricalConnectionId: util.Ptr(model.ElectricalConnectionIdType(1)),
+				ParameterId:            util.Ptr(model.ElectricalConnectionParameterIdType(1)),
+				PermittedValueSet: []model.ScaledNumberSetType{
+					{
+						Range: []model.ScaledNumberRangeType{
+							{
+								Min: &model.ScaledNumberType{
+									Number: util.Ptr(model.NumberType(6)),
+									Scale:  util.Ptr(model.ScaleType(0)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	functionType := model.FunctionTypeElectricalConnectionPermittedValueSetListData
+	sut := NewFunctionData[model.ElectricalConnectionPermittedValueSetListDataType](functionType)
+
+	err := sut.UpdateData(newData, &model.FilterType{CmdControl: &model.CmdControlType{Partial: &model.ElementTagType{}}}, nil)
+	if assert.Nil(t, err) {
+		getData := sut.Data()
+		assert.Equal(t, 1, len(getData.ElectricalConnectionPermittedValueSetData))
+	}
+}
+
+func TestFunctionData_UpdateDataPartial_NotSupported(t *testing.T) {
+	newData := &model.HvacOverrunListDataType{
+		HvacOverrunData: []model.HvacOverrunDataType{
+			{
+				OverrunId: util.Ptr(model.HvacOverrunIdType(1)),
+			},
+		},
+	}
+	functionType := model.FunctionTypeHvacOverrunListData
+	sut := NewFunctionData[model.HvacOverrunListDataType](functionType)
+
+	err := sut.UpdateData(newData, &model.FilterType{CmdControl: &model.CmdControlType{Partial: &model.ElementTagType{}}}, nil)
+	assert.NotNil(t, err)
+	assert.Equal(t, "partial updates are not supported for type 'HvacOverrunListDataType'", string(*err.Description))
 }

--- a/spine/integration_tests/electricalconnection_test.go
+++ b/spine/integration_tests/electricalconnection_test.go
@@ -1,0 +1,91 @@
+package integrationtests
+
+import (
+	"testing"
+
+	"github.com/DerAndereAndi/eebus-go/spine"
+	"github.com/DerAndereAndi/eebus-go/spine/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	ec_detaileddiscoverydata_recv_reply_file_path              = "./testdata/ec_detaileddiscoverydata_recv_reply.json"
+	ec_permittedvaluesetlistdata_recv_notify_partial_file_path = "./testdata/ec_permittedvaluesetlistdata_recv_notify_partial.json"
+	ec_subscriptionRequestCall_recv_result_file_path           = "./testdata/ec_subscriptionRequestCall_recv_result.json"
+)
+
+func TestElectricalConnectionSuite(t *testing.T) {
+	suite.Run(t, new(ElectricalConnectionSuite))
+}
+
+type ElectricalConnectionSuite struct {
+	suite.Suite
+	sut       *spine.DeviceLocalImpl
+	remoteSki string
+	readC     chan []byte
+	writeC    chan []byte
+}
+
+func (s *ElectricalConnectionSuite) SetupSuite() {
+}
+
+func (s *ElectricalConnectionSuite) BeforeTest(suiteName, testName string) {
+	s.sut = spine.NewDeviceLocalImpl("TestBrandName", "TestDeviceModel", "TestDeviceCode",
+		"TestSerialNumber", "TestDeviceAddress", model.DeviceTypeTypeEnergyManagementSystem, model.NetworkManagementFeatureSetTypeSmart)
+	localEntity := spine.NewEntityLocalImpl(s.sut, model.EntityTypeTypeCEM, spine.NewAddressEntityType([]uint{1}))
+	s.sut.AddEntity(localEntity)
+	f := spine.NewFeatureLocalImpl(1, localEntity, model.FeatureTypeTypeElectricalConnection, model.RoleTypeClient)
+	localEntity.AddFeature(f)
+
+	s.remoteSki = "TestRemoteSki"
+
+	s.readC = make(chan []byte, 1)
+	s.writeC = make(chan []byte, 1)
+
+	s.sut.AddRemoteDevice(s.remoteSki, s.readC, s.writeC)
+}
+
+func (s *ElectricalConnectionSuite) AfterTest(suiteName, testName string) {
+}
+
+func (s *ElectricalConnectionSuite) TestPermittedValueSetListData_RecvNotifyPartial() {
+	<-s.writeC // ignore NodeManagementDetailedDiscoveryData read
+
+	// init with detaileddiscoverydata
+	s.readC <- loadFileData(s.T(), ec_detaileddiscoverydata_recv_reply_file_path)
+	<-s.writeC // ignore NodeManagementSubscriptionRequestCall
+	s.readC <- loadFileData(s.T(), ec_subscriptionRequestCall_recv_result_file_path)
+	<-s.writeC // ignore NodeManagementUseCaseData read
+
+	// Act
+	s.readC <- loadFileData(s.T(), ec_permittedvaluesetlistdata_recv_notify_partial_file_path)
+	<-s.writeC // wait for ack
+
+	// Assert
+	remoteDevice := s.sut.RemoteDeviceForSki(s.remoteSki)
+	assert.NotNil(s.T(), remoteDevice)
+
+	ecFeature := remoteDevice.FeatureByEntityTypeAndRole(
+		remoteDevice.Entity(spine.NewAddressEntityType([]uint{1})),
+		model.FeatureTypeTypeElectricalConnection,
+		model.RoleTypeServer)
+	assert.NotNil(s.T(), ecFeature)
+
+	data := ecFeature.Data(model.FunctionTypeElectricalConnectionPermittedValueSetListData).(*model.ElectricalConnectionPermittedValueSetListDataType)
+	if assert.NotNil(s.T(), data) {
+		if assert.Equal(s.T(), 3, len(data.ElectricalConnectionPermittedValueSetData)) {
+			item1 := data.ElectricalConnectionPermittedValueSetData[0]
+			assert.Equal(s.T(), 0, int(*item1.ElectricalConnectionId))
+			assert.Equal(s.T(), 1, int(*item1.ParameterId))
+			assert.Equal(s.T(), 1, len(item1.PermittedValueSet))
+			assert.Equal(s.T(), 1, len(item1.PermittedValueSet[0].Range))
+			assert.NotNil(s.T(), item1.PermittedValueSet[0].Range)
+			assert.Equal(s.T(), 6, int(*item1.PermittedValueSet[0].Range[0].Min.Number))
+			assert.Equal(s.T(), 0, int(*item1.PermittedValueSet[0].Range[0].Min.Scale))
+			assert.Equal(s.T(), 16, int(*item1.PermittedValueSet[0].Range[0].Max.Number))
+			assert.Equal(s.T(), 0, int(*item1.PermittedValueSet[0].Range[0].Max.Scale))
+			assert.Nil(s.T(), item1.PermittedValueSet[0].Value)
+		}
+	}
+}

--- a/spine/integration_tests/testdata/ec_detaileddiscoverydata_recv_reply.json
+++ b/spine/integration_tests/testdata/ec_detaileddiscoverydata_recv_reply.json
@@ -1,0 +1,186 @@
+{
+    "datagram": {
+        "header": {
+            "specificationVersion": "1.1.1",
+            "addressSource": {
+                "entity": [
+                    0
+                ],
+                "feature": 0
+            },
+            "addressDestination": {
+                "device": "TestDeviceAddress",
+                "entity": [
+                    0
+                ],
+                "feature": 0
+            },
+            "msgCounter": 2,
+            "msgCounterReference": 1,
+            "cmdClassifier": "reply"
+        },
+        "payload": {
+            "cmd": [
+                {
+                    "nodeManagementDetailedDiscoveryData": {
+                        "specificationVersionList": {
+                            "specificationVersion": [
+                                "1.1.1"
+                            ]
+                        },
+                        "deviceInformation": {
+                            "description": {
+                                "deviceAddress": {
+                                    "device": "HEMS"
+                                },
+                                "deviceType": "EnergyManagementSystem",
+                                "networkFeatureSet": "smart"
+                            }
+                        },
+                        "entityInformation": [
+                            {
+                                "description": {
+                                    "entityAddress": {
+                                        "device": "HEMS",
+                                        "entity": [
+                                            0
+                                        ]
+                                    },
+                                    "entityType": "DeviceInformation"
+                                }
+                            },
+                            {
+                                "description": {
+                                    "entityAddress": {
+                                        "device": "HEMS",
+                                        "entity": [
+                                            1
+                                        ]
+                                    },
+                                    "entityType": "CEM"
+                                }
+                            }                        
+						],
+                        "featureInformation": [
+                            {
+                                "description": {
+                                    "featureAddress": {
+                                        "device": "HEMS",
+                                        "entity": [
+                                            0
+                                        ],
+                                        "feature": 0
+                                    },
+                                    "featureType": "NodeManagement",
+                                    "role": "special",
+                                    "supportedFunction": [
+                                        {
+                                            "function": "nodeManagementSubscriptionDeleteCall",
+                                            "possibleOperations": {}
+                                        },
+                                        {
+                                            "function": "nodeManagementBindingData",
+                                            "possibleOperations": {
+                                                "read": {}
+                                            }
+                                        },
+                                        {
+                                            "function": "nodeManagementBindingRequestCall",
+                                            "possibleOperations": {}
+                                        },
+                                        {
+                                            "function": "nodeManagementBindingDeleteCall",
+                                            "possibleOperations": {}
+                                        },
+                                        {
+                                            "function": "nodeManagementDetailedDiscoveryData",
+                                            "possibleOperations": {
+                                                "read": {}
+                                            }
+                                        },
+                                        {
+                                            "function": "nodeManagementUseCaseData",
+                                            "possibleOperations": {
+                                                "read": {}
+                                            }
+                                        },
+                                        {
+                                            "function": "nodeManagementSubscriptionData",
+                                            "possibleOperations": {
+                                                "read": {}
+                                            }
+                                        },
+                                        {
+                                            "function": "nodeManagementSubscriptionRequestCall",
+                                            "possibleOperations": {}
+                                        }									
+                                    ]
+                                }
+                            },
+                            {
+                                "description": {
+                                    "featureAddress": {
+                                        "device": "HEMS",
+                                        "entity": [
+                                            0
+                                        ],
+                                        "feature": 1
+                                    },
+                                    "featureType": "DeviceClassification",
+                                    "role": "server",
+                                    "supportedFunction": [
+                                        {
+                                            "function": "deviceClassificationManufacturerData",
+                                            "possibleOperations": {
+                                                "read": {}
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "description": {
+                                    "featureAddress": {
+                                        "device": "HEMS",
+                                        "entity": [
+                                            1
+                                        ],
+                                        "feature": 1
+                                    },
+                                    "featureType": "DeviceClassification",
+                                    "role": "client"
+                                }
+                            },
+                            {
+                                "description": {
+                                    "featureAddress": {
+                                        "device": "HEMS",
+                                        "entity": [
+                                            1
+                                        ],
+                                        "feature": 2
+                                    },
+                                    "featureType": "DeviceDiagnosis",
+                                    "role": "client"
+                                }
+                            },
+                            {
+                                "description": {
+                                    "featureAddress": {
+                                        "device": "HEMS",
+                                        "entity": [
+                                            1
+                                        ],
+                                        "feature": 3
+                                    },
+                                    "featureType": "ElectricalConnection",
+                                    "role": "server"
+                                }
+                            }							
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/spine/integration_tests/testdata/ec_permittedvaluesetlistdata_recv_notify_partial.json
+++ b/spine/integration_tests/testdata/ec_permittedvaluesetlistdata_recv_notify_partial.json
@@ -1,0 +1,101 @@
+{
+    "datagram": {
+        "header": {
+            "specificationVersion": "1.2.0",
+            "addressSource": {
+                "device": "HEMS",
+                "entity": [
+                    1
+                ],
+                "feature": 3
+            },
+            "addressDestination": {
+                "entity": [
+                    1
+                ],
+                "feature": 1
+            },
+            "msgCounter": 1,
+            "cmdClassifier": "notify",
+            "ackRequest":true
+        },
+        "payload": {
+            "cmd": [
+                {
+                    "function":"electricalConnectionPermittedValueSetListData",
+                    "filter":[
+                        {
+                            "cmdControl":{
+                                "partial":{}
+                            }
+                        }
+                    ],
+                    "electricalConnectionPermittedValueSetListData": {
+                        "electricalConnectionPermittedValueSetData": [
+                            {
+                                "electricalConnectionId":0,
+                                "parameterId":1,
+                                "permittedValueSet": [
+                                    {
+                                        "range": [
+                                            {
+                                                "min": {
+                                                    "number":6,
+                                                    "scale":0
+                                                },
+                                                "max": {
+                                                    "number":16,
+                                                    "scale":0
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "electricalConnectionId":0,
+                                "parameterId":2,
+                                "permittedValueSet": [
+                                    {
+                                        "range": [
+                                            {
+                                                "min": {
+                                                    "number":6,
+                                                    "scale":0
+                                                },
+                                                "max": {
+                                                    "number":16,
+                                                    "scale":0
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "electricalConnectionId":0,
+                                "parameterId":3,
+                                "permittedValueSet": [
+                                    {
+                                        "range": [
+                                            {
+                                                "min": {
+                                                    "number":6,
+                                                    "scale":0
+                                                },
+                                                "max": {
+                                                    "number":16,
+                                                    "scale":0
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/spine/integration_tests/testdata/ec_subscriptionRequestCall_recv_result.json
+++ b/spine/integration_tests/testdata/ec_subscriptionRequestCall_recv_result.json
@@ -1,0 +1,32 @@
+{
+    "datagram": {
+        "header": {
+            "specificationVersion": "1.1.1",
+            "addressSource": {
+                "device": "HEMS",
+                "entity": [
+                    0
+                ],
+                "feature": 0
+            },
+            "addressDestination": {
+                "entity": [
+                    0
+                ],
+                "feature": 0
+            },
+            "msgCounter": 3,
+            "msgCounterReference": 2,
+            "cmdClassifier": "result"
+        },
+        "payload": {
+            "cmd": [
+                {
+                    "resultData": {
+                        "errorNumber": 0
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/spine/model/commandframe_additions.go
+++ b/spine/model/commandframe_additions.go
@@ -69,3 +69,7 @@ func (cmd *CmdType) ExtractFilter() (filterPartial *FilterType, filterDelete *Fi
 	}
 	return
 }
+
+func NewFilterTypePartial() *FilterType {
+	return &FilterType{CmdControl: &CmdControlType{Partial: &ElementTagType{}}}
+}

--- a/spine/model/commondatatypes_additions.go
+++ b/spine/model/commondatatypes_additions.go
@@ -10,6 +10,10 @@ import (
 	"github.com/rickb777/date/period"
 )
 
+type Updater[T any] interface {
+	Update(s *T, filterPartial *FilterType, filterDelete *FilterType)
+}
+
 func (m ScaledNumberType) GetValue() float64 {
 	if m.Number == nil {
 		return 0

--- a/spine/model/electricalconnection_additions.go
+++ b/spine/model/electricalconnection_additions.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"fmt"
+
+	"github.com/DerAndereAndi/eebus-go/util"
+)
+
+var _ Updater[ElectricalConnectionPermittedValueSetListDataType] = (*ElectricalConnectionPermittedValueSetListDataType)(nil)
+
+func (r *ElectricalConnectionPermittedValueSetListDataType) Update(s *ElectricalConnectionPermittedValueSetListDataType, filterPartial *FilterType, filterDelete *FilterType) {
+	if s == nil {
+		return
+	}
+
+	// TODO: consider filterPartial and filterDelete
+	newList := util.Union(r.ElectricalConnectionPermittedValueSetData, s.ElectricalConnectionPermittedValueSetData, CalcHash)
+
+	r.ElectricalConnectionPermittedValueSetData = newList
+}
+
+func CalcHash(s *ElectricalConnectionPermittedValueSetDataType) string {
+	return fmt.Sprintf("%d|%d", *s.ElectricalConnectionId, *s.ParameterId)
+}

--- a/spine/model/electricalconnection_additions_test.go
+++ b/spine/model/electricalconnection_additions_test.go
@@ -1,0 +1,83 @@
+package model_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/DerAndereAndi/eebus-go/spine/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestElectricalConnectionPermittedValueSetListDataType_Update_NewItem(t *testing.T) {
+	existingDataJson := `{
+		"electricalConnectionPermittedValueSetData": [
+		  {
+			"electricalConnectionId": 1,
+			"parameterId": 1,
+			"permittedValueSet": [
+			  {
+				"range": [
+				  {
+					"min": { "number": 3, "scale": 0 },
+					"max": { "number": 6, "scale": 0 }
+				  }
+				]
+			  }
+			]
+		  }
+		]
+	}`
+
+	var sut model.ElectricalConnectionPermittedValueSetListDataType
+	err := json.Unmarshal([]byte(existingDataJson), &sut)
+	if assert.Nil(t, err) == false {
+		return
+	}
+
+	newDataJson := `{
+		"electricalConnectionPermittedValueSetData": [
+		  {
+			"electricalConnectionId": 1,
+			"parameterId": 2,
+			"permittedValueSet": [
+			  {
+				"range": [
+				  {
+					"min": { "number": 9, "scale": 0 },
+					"max": { "number": 19, "scale": 0 }
+				  }
+				]
+			  },
+			  {
+				"range": [
+				  {
+					"min": { "number": 30, "scale": 0 },
+					"max": { "number": 36, "scale": 0 }
+				  }
+				]
+			  }
+			]
+		  }
+		]
+	}`
+
+	var newData model.ElectricalConnectionPermittedValueSetListDataType
+	err = json.Unmarshal([]byte(newDataJson), &newData)
+	if assert.Nil(t, err) == false {
+		return
+	}
+
+	// Act
+	sut.Update(&newData, model.NewFilterTypePartial(), nil)
+
+	if assert.Equal(t, 2, len(sut.ElectricalConnectionPermittedValueSetData)) {
+		item1 := sut.ElectricalConnectionPermittedValueSetData[0]
+		assert.Equal(t, 1, int(*item1.ElectricalConnectionId))
+		assert.Equal(t, 1, int(*item1.ParameterId))
+		assert.Equal(t, 1, len(item1.PermittedValueSet))
+		item2 := sut.ElectricalConnectionPermittedValueSetData[1]
+		assert.Equal(t, 1, int(*item2.ElectricalConnectionId))
+		assert.Equal(t, 2, int(*item2.ParameterId))
+		assert.Equal(t, 2, len(item2.PermittedValueSet))
+	}
+}

--- a/util/collection_operations.go
+++ b/util/collection_operations.go
@@ -1,0 +1,60 @@
+package util
+
+func FindFirst[T any](s []T, predicate func(i T) bool) *T {
+	for _, item := range s {
+		if predicate(item) {
+			return &item
+		}
+	}
+	return nil
+}
+
+// Creates the union of two slices. The item in the second slice will replace the one in the first slice
+// if the hash value is the same. Items in the second slice which are not in the first will be added.
+func Union[T any](s1 []T, s2 []T, hasher func(i *T) string) []T {
+	result := []T{}
+
+	m2 := ToMap(s2, hasher)
+
+	// go through the first slice
+	m1 := make(map[string]T, len(s1))
+	for _, s1Item := range s1 {
+		s1ItemHash := hasher(&s1Item)
+		s2Item, exist := m2[s1ItemHash]
+		if exist {
+			// the item in the first slice will be replaces by the one of the second slice
+			result = append(result, s2Item)
+		} else {
+			result = append(result, s1Item)
+		}
+
+		m1[s1ItemHash] = s1Item
+	}
+
+	// append items which were not in the first slice
+	for _, s2Item := range s2 {
+		s2ItemHash := hasher(&s2Item)
+		_, exist := m1[s2ItemHash]
+		if !exist {
+			result = append(result, s2Item)
+		}
+	}
+
+	return result
+}
+
+func ToMap[T any](s []T, hasher func(i *T) string) map[string]T {
+	result := make(map[string]T, len(s))
+	for _, item := range s {
+		result[hasher(&item)] = item
+	}
+	return result
+}
+
+func Values[K comparable, V any](m map[K]V) []V {
+	ret := make([]V, 0, len(m))
+	for _, v := range m {
+		ret = append(ret, v)
+	}
+	return ret
+}

--- a/util/collection_operations_test.go
+++ b/util/collection_operations_test.go
@@ -1,0 +1,62 @@
+package util_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/DerAndereAndi/eebus-go/util"
+	"github.com/stretchr/testify/assert"
+)
+
+type testStruct struct {
+	id   int
+	data string
+}
+
+func calcHash(s *testStruct) string {
+	return fmt.Sprintf("%d", s.id)
+}
+
+func TestUnion_NewData(t *testing.T) {
+	existingData := []testStruct{
+		{id: 1, data: "data1"},
+	}
+
+	newData := []testStruct{
+		{id: 2, data: "data2"},
+	}
+
+	// Act
+	result := util.Union(existingData, newData, calcHash)
+
+	if assert.Equal(t, 2, len(result)) {
+		assert.Equal(t, 1, result[0].id)
+		assert.Equal(t, "data1", result[0].data)
+		assert.Equal(t, 2, result[1].id)
+		assert.Equal(t, "data2", result[1].data)
+	}
+}
+
+func TestUnion_NewAndUpdateData(t *testing.T) {
+	existingData := []testStruct{
+		{id: 1, data: "data1"},
+		{id: 2, data: "data2"},
+	}
+
+	newData := []testStruct{
+		{id: 2, data: "data22"},
+		{id: 3, data: "data33"},
+	}
+
+	// Act
+	result := util.Union(existingData, newData, calcHash)
+
+	if assert.Equal(t, 3, len(result)) {
+		assert.Equal(t, 1, result[0].id)
+		assert.Equal(t, "data1", result[0].data)
+		assert.Equal(t, 2, result[1].id)
+		assert.Equal(t, "data22", result[1].data)
+		assert.Equal(t, 3, result[2].id)
+		assert.Equal(t, "data33", result[2].data)
+	}
+}


### PR DESCRIPTION
Dieser Ansatz kommt ohne zusätzliche Tags im model aus.
Stattdessen muss für jeden Typ eine `Update` Methode implementiert werden (siehe `electricalconnection_additions.go`)
Ich würde als erstes diesen Ansatz weiter verfolgen und prüfen ob er auch für die Implementierung der Selectoren ausreichend ist.
Was meinst du?