### PR TITLE
Updater concept to reduce boilerplate

### DIFF
--- a/spine/model/commondatatypes_additions.go
+++ b/spine/model/commondatatypes_additions.go
@@ -10,10 +10,6 @@ import (
 	"github.com/rickb777/date/period"
 )
 
-type Updater[T any] interface {
-	Update(s *T, filterPartial *FilterType, filterDelete *FilterType)
-}
-
 func (m ScaledNumberType) GetValue() float64 {
 	if m.Number == nil {
 		return 0

--- a/spine/model/electricalconnection_additions.go
+++ b/spine/model/electricalconnection_additions.go
@@ -6,22 +6,28 @@ import (
 	"github.com/DerAndereAndi/eebus-go/util"
 )
 
-var _ Updater[ElectricalConnectionPermittedValueSetListDataType] = (*ElectricalConnectionPermittedValueSetListDataType)(nil)
+var _ UpdaterFactory[ElectricalConnectionPermittedValueSetListDataType] = (*ElectricalConnectionPermittedValueSetListDataType)(nil)
 var _ util.HashKeyer = (*ElectricalConnectionPermittedValueSetDataType)(nil)
 
-func (r *ElectricalConnectionPermittedValueSetListDataType) Update(s *ElectricalConnectionPermittedValueSetListDataType, filterPartial *FilterType, filterDelete *FilterType) {
-	if s == nil {
-		return
+func (r *ElectricalConnectionPermittedValueSetListDataType) NewUpdater(
+	newList *ElectricalConnectionPermittedValueSetListDataType,
+	filterPartial *FilterType,
+	filterDelete *FilterType) Updater {
+
+	return &ElectricalConnectionPermittedValueSetListDataType_Updater{
+		ElectricalConnectionPermittedValueSetListDataType: r,
+		newData:       newList.ElectricalConnectionPermittedValueSetData,
+		filterPartial: filterPartial,
+		filterDelete:  filterDelete,
 	}
-
-	// TODO: consider filterPartial and filterDelete
-	// TODO: consider items without identifiers
-	// TODO: Check if only single fields should be considered here
-	newList := util.Merge(r.ElectricalConnectionPermittedValueSetData, s.ElectricalConnectionPermittedValueSetData)
-
-	r.ElectricalConnectionPermittedValueSetData = newList
 }
 
 func (r ElectricalConnectionPermittedValueSetDataType) HashKey() string {
-	return fmt.Sprintf("%d|%d", *r.ElectricalConnectionId, *r.ParameterId)
+	return electricalConnectionPermittedValueSetDataHashKey(
+		r.ElectricalConnectionId,
+		r.ParameterId)
+}
+
+func electricalConnectionPermittedValueSetDataHashKey(electricalConnectionId *ElectricalConnectionIdType, parameterId *ElectricalConnectionParameterIdType) string {
+	return fmt.Sprintf("%d|%d", *electricalConnectionId, *parameterId)
 }

--- a/spine/model/electricalconnection_additions_test.go
+++ b/spine/model/electricalconnection_additions_test.go
@@ -68,7 +68,7 @@ func TestElectricalConnectionPermittedValueSetListDataType_Update_NewItem(t *tes
 	}
 
 	// Act
-	sut.Update(&newData, model.NewFilterTypePartial(), nil)
+	sut.NewUpdater(&newData, model.NewFilterTypePartial(), nil).DoUpdate()
 
 	if assert.Equal(t, 2, len(sut.ElectricalConnectionPermittedValueSetData)) {
 		item1 := sut.ElectricalConnectionPermittedValueSetData[0]
@@ -79,5 +79,99 @@ func TestElectricalConnectionPermittedValueSetListDataType_Update_NewItem(t *tes
 		assert.Equal(t, 1, int(*item2.ElectricalConnectionId))
 		assert.Equal(t, 2, int(*item2.ParameterId))
 		assert.Equal(t, 2, len(item2.PermittedValueSet))
+	}
+}
+
+func TestElectricalConnectionPermittedValueSetListDataType_UpdateWithoutIdenifiers(t *testing.T) {
+	existingDataJson := `{
+		"electricalConnectionPermittedValueSetData": [
+		  {
+			"electricalConnectionId": 1,
+			"parameterId": 1,
+			"permittedValueSet": [
+			  {
+				"range": [
+				  {
+					"min": { "number": 3, "scale": 0 },
+					"max": { "number": 6, "scale": 0 }
+				  }
+				]
+			  }
+			]
+		  },
+		  {
+			"electricalConnectionId": 1,
+			"parameterId": 2,
+			"permittedValueSet": [
+			  {
+				"range": [
+				  {
+					"min": { "number": 6, "scale": 0 },
+					"max": { "number": 12, "scale": 0 }
+				  }
+				]
+			  }
+			]
+		  }		]
+	}`
+
+	var sut model.ElectricalConnectionPermittedValueSetListDataType
+	err := json.Unmarshal([]byte(existingDataJson), &sut)
+	if assert.Nil(t, err) == false {
+		return
+	}
+
+	newDataJson := `{
+		"electricalConnectionPermittedValueSetData": [
+		  {
+			"permittedValueSet": [
+			  {
+				"range": [
+				  {
+					"min": { "number": 30, "scale": 0 },
+					"max": { "number": 36, "scale": 0 }
+				  }
+				]
+			  }
+			]
+		  }
+		]
+	}`
+
+	var newData model.ElectricalConnectionPermittedValueSetListDataType
+	err = json.Unmarshal([]byte(newDataJson), &newData)
+	if assert.Nil(t, err) == false {
+		return
+	}
+
+	// Act
+	sut.NewUpdater(&newData, model.NewFilterTypePartial(), nil).DoUpdate()
+
+	if assert.Equal(t, 2, len(sut.ElectricalConnectionPermittedValueSetData)) {
+		item1 := sut.ElectricalConnectionPermittedValueSetData[0]
+		assert.Equal(t, 1, int(*item1.ElectricalConnectionId))
+		assert.Equal(t, 1, int(*item1.ParameterId))
+		if assert.Equal(t, 1, len(item1.PermittedValueSet)) {
+			valueSet := item1.PermittedValueSet[0]
+			if assert.Equal(t, 1, len(valueSet.Range)) {
+				assert.Equal(t, 30, int(*valueSet.Range[0].Min.Number))
+				assert.Equal(t, 0, int(*valueSet.Range[0].Min.Scale))
+				assert.Equal(t, 36, int(*valueSet.Range[0].Max.Number))
+				assert.Equal(t, 0, int(*valueSet.Range[0].Max.Scale))
+			}
+		}
+
+		item2 := sut.ElectricalConnectionPermittedValueSetData[1]
+		assert.Equal(t, 1, int(*item2.ElectricalConnectionId))
+		assert.Equal(t, 2, int(*item2.ParameterId))
+		if assert.Equal(t, 1, len(item2.PermittedValueSet)) {
+			valueSet := item2.PermittedValueSet[0]
+			if assert.Equal(t, 1, len(valueSet.Range)) {
+				assert.Equal(t, 30, int(*valueSet.Range[0].Min.Number))
+				assert.Equal(t, 0, int(*valueSet.Range[0].Min.Scale))
+				assert.Equal(t, 36, int(*valueSet.Range[0].Max.Number))
+				assert.Equal(t, 0, int(*valueSet.Range[0].Max.Scale))
+			}
+		}
 	}
 }

--- a/spine/model/electricalconnection_updater.go
+++ b/spine/model/electricalconnection_updater.go
@@ -1,0 +1,53 @@
+package model
+
+import "github.com/DerAndereAndi/eebus-go/util"
+
+var _ Updater = (*ElectricalConnectionPermittedValueSetListDataType_Updater)(nil)
+var _ UpdateDataProvider[ElectricalConnectionPermittedValueSetDataType] = (*ElectricalConnectionPermittedValueSetListDataType_Updater)(nil)
+
+type ElectricalConnectionPermittedValueSetListDataType_Updater struct {
+	*ElectricalConnectionPermittedValueSetListDataType
+	newData       []ElectricalConnectionPermittedValueSetDataType
+	filterPartial *FilterType
+	filterDelete  *FilterType
+}
+
+func (r *ElectricalConnectionPermittedValueSetListDataType_Updater) DoUpdate() {
+	r.ElectricalConnectionPermittedValueSetData = UpdateList[ElectricalConnectionPermittedValueSetDataType](r)
+}
+
+func (r *ElectricalConnectionPermittedValueSetListDataType_Updater) ExistingData() []ElectricalConnectionPermittedValueSetDataType {
+	return r.ElectricalConnectionPermittedValueSetData
+}
+
+func (r *ElectricalConnectionPermittedValueSetListDataType_Updater) NewData() []ElectricalConnectionPermittedValueSetDataType {
+	return r.newData
+}
+
+func (r *ElectricalConnectionPermittedValueSetListDataType_Updater) UpdateSelektorHashKey() *string {
+	return r.selektorHashKey(r.filterPartial)
+}
+
+func (r *ElectricalConnectionPermittedValueSetListDataType_Updater) DeleteSelektorHashKey() *string {
+	return r.selektorHashKey(r.filterDelete)
+}
+
+func (r *ElectricalConnectionPermittedValueSetListDataType_Updater) HasIdentifier(item *ElectricalConnectionPermittedValueSetDataType) bool {
+	return item.ElectricalConnectionId != nil && item.ParameterId != nil
+}
+
+func (r *ElectricalConnectionPermittedValueSetListDataType_Updater) CopyData(source *ElectricalConnectionPermittedValueSetDataType, dest *ElectricalConnectionPermittedValueSetDataType) {
+	if source != nil && dest != nil {
+		dest.PermittedValueSet = source.PermittedValueSet
+	}
+}
+
+func (r *ElectricalConnectionPermittedValueSetListDataType_Updater) selektorHashKey(filter *FilterType) *string {
+	var result *string = nil
+	if filter != nil && filter.ElectricalConnectionPermittedValueSetListDataSelectors != nil {
+		result = util.Ptr(electricalConnectionPermittedValueSetDataHashKey(
+			filter.ElectricalConnectionPermittedValueSetListDataSelectors.ElectricalConnectionId,
+			filter.ElectricalConnectionPermittedValueSetListDataSelectors.ParameterId))
+	}
+	return result
+}

--- a/spine/model/update.go
+++ b/spine/model/update.go
@@ -1,0 +1,64 @@
+package model
+
+import "github.com/DerAndereAndi/eebus-go/util"
+
+type Updater interface {
+	DoUpdate()
+}
+
+type UpdaterFactory[T any] interface {
+	NewUpdater(s *T, filterPartial *FilterType, filterDelete *FilterType) Updater
+}
+
+type UpdateDataProvider[T util.HashKeyer] interface {
+	ExistingData() []T
+	NewData() []T
+	UpdateSelektorHashKey() *string
+	DeleteSelektorHashKey() *string
+	HasIdentifier(*T) bool
+	CopyData(source *T, dest *T)
+}
+
+func UpdateList[T util.HashKeyer](dataProvider UpdateDataProvider[T]) []T {
+	newData := dataProvider.NewData()
+	existingData := dataProvider.ExistingData()
+	if len(newData) == 0 {
+		return existingData
+	}
+
+	// TODO: consider filterDelete
+	// TODO: Check if only single fields should be considered here
+
+	// check if selector is used
+	updateSelectorHashKey := dataProvider.UpdateSelektorHashKey()
+	if updateSelectorHashKey != nil {
+		return copyToSelectedData(dataProvider, &newData[0], *updateSelectorHashKey)
+	}
+
+	// check if items have no identifiers
+	if !dataProvider.HasIdentifier(&newData[0]) {
+		// no identifiers specified --> copy data to all existing items
+		return copyToAllData(dataProvider, &newData[0])
+	}
+
+	return util.Merge(existingData, newData)
+}
+
+func copyToSelectedData[T util.HashKeyer](dataProvider UpdateDataProvider[T], newData *T, selectorHashKey string) []T {
+	existingData := dataProvider.ExistingData()
+	for i := range existingData {
+		if existingData[i].HashKey() == selectorHashKey {
+			dataProvider.CopyData(newData, &existingData[i])
+			break
+		}
+	}
+	return existingData
+}
+
+func copyToAllData[T util.HashKeyer](dataProvider UpdateDataProvider[T], newData *T) []T {
+	existingData := dataProvider.ExistingData()
+	for i := range existingData {
+		dataProvider.CopyData(newData, &existingData[i])
+	}
+	return existingData
+}

--- a/util/collection_operations.go
+++ b/util/collection_operations.go
@@ -62,3 +62,12 @@ func Values[K comparable, V any](m map[K]V) []V {
 	}
 	return ret
 }
+
+// casts all elements in slice s to type D
+func CastElements[S any, D any](s []S) []D {
+	result := make([]D, len(s))
+	for i, item := range s {
+		result[i] = any(item).(D)
+	}
+	return result
+}

--- a/util/type.go
+++ b/util/type.go
@@ -1,0 +1,13 @@
+package util
+
+import "reflect"
+
+func Type[T any]() reflect.Type {
+	return reflect.TypeOf((*T)(nil)).Elem()
+}
+
+// checks if type T implements interface I
+func Implements[T any, I any]() bool {
+	_, supported := any((*T)(nil)).(I)
+	return supported
+}


### PR DESCRIPTION
Implementation of a new  `Updater` concept for `ElectricalConnectionPermittedValueSetListDataType` so that other model classes can be integrated easier.

Furthermore 

- Update with selectors
- Update without indentifiers

are now supported.
